### PR TITLE
feat: qualquer link serve para renderizar a imagem

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**', 
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Mudança na configuração do Next.js para aceitar qualquer link ao cadastrar a imagem da viagem